### PR TITLE
Updated git submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/dapphub/ds-test
 [submodule "lib/ds-proxy"]
 	path = lib/ds-proxy
-	url = https://github.com/dapphub/ds-proxy/
+	url = https://github.com/dapphub/ds-proxy


### PR DESCRIPTION
On some MacOS machines it shows error that submodule couldn't be load.

```
Submodule 'lib/ds-proxy' (https://github.com/dapphub/ds-proxy/) registered for path 'testchain/lib/proxy-registry/lib/ds-proxy'
Submodule 'lib/ds-test' (https://github.com/dapphub/ds-test) registered for path 'testchain/lib/proxy-registry/lib/ds-test'
Cloning into '*****/dai.js/testchain/lib/proxy-registry/lib/ds-proxy'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https://github.com/dapphub/ds-proxy/' into submodule path '*****/dai.js/testchain/lib/proxy-registry/lib/ds-proxy' failed
Failed to clone 'lib/ds-proxy'. Retry scheduled
Cloning into '*****/dai.js/testchain/lib/proxy-registry/lib/ds-test'...
Cloning into '*****/dai.js/testchain/lib/proxy-registry/lib/ds-proxy'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https://github.com/dapphub/ds-proxy/' into submodule path '*****/dai.js/testchain/lib/proxy-registry/lib/ds-proxy' failed
Failed to clone 'lib/ds-proxy' a second time, aborting
```