### PR TITLE
Registry update

### DIFF
--- a/src/ProxyRegistry.sol
+++ b/src/ProxyRegistry.sol
@@ -30,10 +30,12 @@ contract ProxyRegistry {
         factory = DSProxyFactory(factory_);
     }
 
-    function claim(address payable proxy) external {
+    function claim(address payable proxy, address prevOwner) external {
         require(proxies[msg.sender] == DSProxy(0) || proxies[msg.sender].owner() != msg.sender, "ProxyRegistry/proxy-registered-to-owner"); // Not allow new proxy if the user already has one and remains being the owner
         require(DSProxy(proxy).owner() == msg.sender, "ProxyRegistry/proxy-not-owned-by-caller");
+        require(proxies[prevOwner] == DSProxy(proxy), "ProxyRegistry/must-provide-a-valid-previous-owner");
 
+        proxies[prevOwner] = DSProxy(0);
         proxies[msg.sender] = DSProxy(proxy);
     }
 

--- a/src/ProxyRegistry.sol
+++ b/src/ProxyRegistry.sol
@@ -32,7 +32,7 @@ contract ProxyRegistry {
 
     function claim(address payable proxy, address src, address dst) external {
         require(proxies[dst] == DSProxy(0) || proxies[dst].owner() != dst, "ProxyRegistry/proxy-registered-to-owner"); // Not allow new proxy if the user already has one and remains being the owner
-        require(DSProxy(proxy).owner() == dst, "ProxyRegistry/proxy-not-owned-by-caller");
+        require(DSProxy(proxy).owner() == dst, "ProxyRegistry/proxy-not-owned-by-dst");
         require(proxies[src] == DSProxy(proxy), "ProxyRegistry/must-provide-a-valid-previous-owner");
 
         proxies[src] = DSProxy(0);

--- a/src/ProxyRegistry.sol
+++ b/src/ProxyRegistry.sol
@@ -30,13 +30,13 @@ contract ProxyRegistry {
         factory = DSProxyFactory(factory_);
     }
 
-    function claim(address payable proxy, address prevOwner) external {
-        require(proxies[msg.sender] == DSProxy(0) || proxies[msg.sender].owner() != msg.sender, "ProxyRegistry/proxy-registered-to-owner"); // Not allow new proxy if the user already has one and remains being the owner
-        require(DSProxy(proxy).owner() == msg.sender, "ProxyRegistry/proxy-not-owned-by-caller");
-        require(proxies[prevOwner] == DSProxy(proxy), "ProxyRegistry/must-provide-a-valid-previous-owner");
+    function claim(address payable proxy, address src, address dst) external {
+        require(proxies[dst] == DSProxy(0) || proxies[dst].owner() != dst, "ProxyRegistry/proxy-registered-to-owner"); // Not allow new proxy if the user already has one and remains being the owner
+        require(DSProxy(proxy).owner() == dst, "ProxyRegistry/proxy-not-owned-by-caller");
+        require(proxies[src] == DSProxy(proxy), "ProxyRegistry/must-provide-a-valid-previous-owner");
 
-        proxies[prevOwner] = DSProxy(0);
-        proxies[msg.sender] = DSProxy(proxy);
+        proxies[src] = DSProxy(0);
+        proxies[dst] = DSProxy(proxy);
     }
 
     // deploys a new proxy instance

--- a/src/ProxyRegistry.sol
+++ b/src/ProxyRegistry.sol
@@ -30,6 +30,13 @@ contract ProxyRegistry {
         factory = DSProxyFactory(factory_);
     }
 
+    function claim(address payable proxy) external {
+        require(proxies[msg.sender] == DSProxy(0) || proxies[msg.sender].owner() != msg.sender, "ProxyRegistry/proxy-registered-to-owner"); // Not allow new proxy if the user already has one and remains being the owner
+        require(DSProxy(proxy).owner() == msg.sender, "ProxyRegistry/proxy-not-owned-by-caller");
+
+        proxies[msg.sender] = DSProxy(proxy);
+    }
+
     // deploys a new proxy instance
     // sets owner of proxy to caller
     function build() public returns (address payable proxy) {

--- a/src/ProxyRegistry.t.sol
+++ b/src/ProxyRegistry.t.sol
@@ -11,8 +11,8 @@ contract Usr {
 		proxy.setOwner(dst);
 	}
 
-	function claimProxy(ProxyRegistry registry, address payable proxyAddr) external {
-		registry.claim(proxyAddr);	
+	function claimProxy(ProxyRegistry registry, address payable proxyAddr, address prevOwner) external {
+		registry.claim(proxyAddr, prevOwner);	
 	}
 }
 
@@ -108,11 +108,11 @@ contract ProxyRegistryTest is DSTest {
 		assertEq(address(registry.proxies(address(usr1))), proxyAddr);
 		assertEq(address(registry.proxies(address(usr2))), address(0));
 
-		usr2.claimProxy(registry, proxyAddr);
+		usr2.claimProxy(registry, proxyAddr, address(usr1));
 
 		assertEq(proxy.owner(), address(usr2));
 		// Registry now reports correctly for usr2
-		assertEq(address(registry.proxies(address(usr1))), proxyAddr);
+		assertEq(address(registry.proxies(address(usr1))), address(0));
 		assertEq(address(registry.proxies(address(usr2))), proxyAddr);
 
 		// Can build for usr1 now
@@ -132,7 +132,7 @@ contract ProxyRegistryTest is DSTest {
 		
 		assertEq(address(registry.proxies(address(usr1))), proxyAddr);
 		
-		usr1.claimProxy(registry, proxyAddr);
+		usr1.claimProxy(registry, proxyAddr, address(123));
 	}
 
 	function testFail_ClaimOtherProxy() public {
@@ -144,6 +144,6 @@ contract ProxyRegistryTest is DSTest {
 		
 		assertEq(address(registry.proxies(address(usr1))), proxyAddr);
 		
-		usr2.claimProxy(registry, proxyAddr);
+		usr2.claimProxy(registry, proxyAddr, address(usr1));
 	}
 }

--- a/src/ProxyRegistry.t.sol
+++ b/src/ProxyRegistry.t.sol
@@ -10,10 +10,6 @@ contract Usr {
 	function transferProxy(DSProxy proxy, address dst) external {
 		proxy.setOwner(dst);
 	}
-
-	function claimProxy(ProxyRegistry registry, address payable proxyAddr, address prevOwner) external {
-		registry.claim(proxyAddr, prevOwner);	
-	}
 }
 
 contract ProxyRegistryTest is DSTest {
@@ -108,7 +104,7 @@ contract ProxyRegistryTest is DSTest {
 		assertEq(address(registry.proxies(address(usr1))), proxyAddr);
 		assertEq(address(registry.proxies(address(usr2))), address(0));
 
-		usr2.claimProxy(registry, proxyAddr, address(usr1));
+		registry.claim(proxyAddr, address(usr1), address(usr2));
 
 		assertEq(proxy.owner(), address(usr2));
 		// Registry now reports correctly for usr2
@@ -132,7 +128,7 @@ contract ProxyRegistryTest is DSTest {
 		
 		assertEq(address(registry.proxies(address(usr1))), proxyAddr);
 		
-		usr1.claimProxy(registry, proxyAddr, address(123));
+		registry.claim(proxyAddr, address(usr1), address(123));
 	}
 
 	function testFail_ClaimOtherProxy() public {
@@ -144,6 +140,6 @@ contract ProxyRegistryTest is DSTest {
 		
 		assertEq(address(registry.proxies(address(usr1))), proxyAddr);
 		
-		usr2.claimProxy(registry, proxyAddr, address(usr1));
+		registry.claim(proxyAddr, address(usr1), address(usr2));
 	}
 }


### PR DESCRIPTION
Add a `claim(proxy, src, dst)` function to the proxy registry.  This function can be called by anyone to update the registry after a proxy has been transferred between addresses.